### PR TITLE
Move peek reset to next()

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -111,10 +111,8 @@ impl<'a> Scanner<'a> {
     pub fn peek(&mut self) -> Option<Token> {
         if self.peeked.is_none() {
             self.peeked = self.scan_token();
-            return self.peeked.clone();
-        } else {
-            return self.peeked.clone();
         }
+        self.peeked.clone()
     }
 
     pub fn scan_token(&mut self) -> Option<Token> {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -109,25 +109,16 @@ impl<'a> Scanner<'a> {
     }
 
     pub fn peek(&mut self) -> Option<Token> {
-        let token = self.scan_token();
-
-        match token {
-            None => None,
-            Some(t) => {
-                self.peeked = Some(t);
-                self.peeked.clone()
-            }
+        if self.peeked.is_none() {
+            self.peeked = self.scan_token();
+            return self.peeked.clone();
+        } else {
+            return self.peeked.clone();
         }
     }
 
     pub fn scan_token(&mut self) -> Option<Token> {
-        let mut token: Option<Token> = match self.peeked.clone() {
-            None => None,
-            Some(t) => {
-                self.peeked = None;
-                Some(t)
-            }
-        };
+        let mut token: Option<Token> = None;
 
         while token.is_none() && self.source_chars.peek().is_some() {
             self.col += 1;
@@ -396,7 +387,13 @@ impl<'a> Iterator for Scanner<'a> {
     type Item = Token;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.scan_token()
+        if self.peeked.is_some() {
+            let p = self.peeked.clone();
+            self.peeked = None;
+            p
+        } else {
+            self.scan_token()
+        }
     }
 }
 


### PR DESCRIPTION
Currently Scanner `peek` is not idempotent, which is non-standard. This happens because the second call to `peek` will clear the saved token, and therefore a third call to peek will advance the underlying iterator.

This moves the peeked character reset to `next`, and therefore repeated calls to `peek` will not advance the iterator until the peeked token is consumed.